### PR TITLE
also try upload failed previous attempts

### DIFF
--- a/src/main-page.js
+++ b/src/main-page.js
@@ -35,8 +35,10 @@ function pageController($scope, $interval) {
 			return;
 		}
 
-		// Upload only new replays
-		if (this.replays[replayNumber].status !== Constants.REPLAY_STATUS.NEW) {
+		// Upload only new replays and failed attempts (UnknownCode/UploadError)
+		if (this.replays[replayNumber].status !== Constants.REPLAY_STATUS.NEW &&
+			this.replays[replayNumber].status !== Constants.REPLAY_STATUS.UNKNOWN &&
+			this.replays[replayNumber].status !== Constants.REPLAY_STATUS.UPLOAD_ERROR) {
 			return this.uploadReplay(replayNumber + 1);
 		}
 


### PR DESCRIPTION
Without this modification, if an upload fails once it never gets tried again, unless you clean out the database completely. This way it will be handled same as a new item.